### PR TITLE
feat: :sparkles: CF-109 Custom especific errors

### DIFF
--- a/node-server/src/middlewares/asyncHandler.js
+++ b/node-server/src/middlewares/asyncHandler.js
@@ -1,6 +1,6 @@
 // v1
-// const asyncHandler = (fn) => (req, res, next) =>
-//   Promise.resolve(fn(req, res, next)).catch(next);
+const asyncHandler = (fn) => (req, res, next) =>
+  Promise.resolve(fn(req, res, next)).catch(next)
 
 // v2
 // const asyncHandler = (fn) => {
@@ -8,15 +8,15 @@
 //     try {
 //       if (fn.length > 3) {
 //         // Si la función tiene más de 3 parámetros, asumimos que es un error handler
-//         await fn(err, req, res, next);
+//         await fn(err, req, res, next)
 //       } else {
-//         await fn(req, res, next);
+//         await fn(req, res, next)
 //       }
 //     } catch (error) {
 //       next(error);
 //     }
-//   };
-// };
+//   }
+// }
 
 // v3 combinado
 // const asyncHandler = (fn) => {
@@ -33,16 +33,16 @@
 // };
 
 // v4 separado
-const asyncHandler = (fn) => {
-  return (req, res, next) => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}
+// const asyncHandler = (fn) => {
+//   return (req, res, next) => {
+//     Promise.resolve(fn(req, res, next)).catch(next)
+//   }
+// }
 
-const asyncErrorHandler = (fn) => {
-  return (err, req, res, next) => {
-    Promise.resolve(fn(err, req, res, next)).catch(next)
-  }
-}
+// const asyncErrorHandler = (fn) => {
+//   return (err, req, res, next) => {
+//     Promise.resolve(fn(err, req, res, next)).catch(next)
+//   }
+// }
 
-module.exports = { asyncHandler, asyncErrorHandler }
+module.exports = { asyncHandler }

--- a/node-server/src/middlewares/errorHandler.js
+++ b/node-server/src/middlewares/errorHandler.js
@@ -1,50 +1,30 @@
-// Custom error array
 const customErrors = require('@utils/apiErrors')
 
-const errorHandler = (err, req, res) => {
-  const isCustomError = Object.values(customErrors).some(ErrorType => err instanceof ErrorType)
+const errorHandler = (err, req, res, next) => {
+  console.error('ERROR:', err)
 
-  if (process.env.NODE_ENV === 'development') {
-    console.error('MESSAGE =>', err.message)
-    console.error('STACK =>', err.stack)
+  const isCustomError = Object.values(customErrors).some(
+    (ErrorType) => err instanceof ErrorType
+  )
 
-    if (isCustomError) {
-      return res.status(isCustomError ? err.status : 500).json({
-        status: err.status,
-        success: false,
-        error: {
-          message: isCustomError ? err.message : 'An unexpected error occurred',
-          stack: isCustomError ? err.stack : ''
-        }
-      })
-    } else {
-      return res.status(500).json({
-        status: err.status,
-        success: false,
-        error: {
-          message: err.message || 'An unexpected error occurred',
-          stack: err.stack || ''
-        }
-      })
+  const errorResponse = {
+    status: isCustomError ? err.status : 500,
+    success: false,
+    error: {
+      message: isCustomError ? err.message : 'An unexpected error occurred',
+      code: isCustomError ? err.code : 'UNKNOWN_ERROR'
     }
   }
 
-  console.error(err.message)
-
-  if (isCustomError) {
-    return res.status(err.status).json({
-      status: err.status,
-      success: false,
-      error: err.message
-    })
+  if (process.env.NODE_ENV === 'development') {
+    console.error('NAME =>', err.name)
+    console.error('MESSAGE =>', err.message)
+    console.error('STACK =>', err.stack)
+    console.error('TYPE =>', err.code)
+    errorResponse.error.stack = err.stack
   }
 
-  // In production, send a generic message for non-custom errors
-  res.status(500).json({
-    status: 500,
-    success: false,
-    error: err.message
-  })
+  res.status(errorResponse.status).json(errorResponse)
 }
 
 module.exports = errorHandler

--- a/node-server/src/utils/apiErrors.js
+++ b/node-server/src/utils/apiErrors.js
@@ -1,48 +1,45 @@
-class ValidationError extends Error {
-  constructor (message) {
+class AbstractError extends Error {
+  constructor (message, status, code) {
     super(message)
-    this.name = 'ValidationError'
-    this.status = 400
+    this.name = this.constructor.name
+    this.code = code
+    this.status = status
   }
 }
 
-class AuthorizationError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'AuthorizationError'
-    this.status = 401
+class ValidationError extends AbstractError {
+  constructor (messsage = 'Validation error', code = 'AUTH_000') {
+    super(messsage, 400, code)
   }
 }
 
-class UnauthorizedError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'UnauthorizedError'
-    this.status = 403
+class AuthorizationError extends AbstractError {
+  constructor (message = 'Unauthorized', code = 'AUTH_001') {
+    super(message, 401, 'AUTH_001')
   }
 }
 
-class NotFoundError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'NotFoundError'
-    this.status = 404
+class UnauthorizedError extends AbstractError {
+  constructor (message = 'Unauthorized', code = 'AUTH_002') {
+    super(message, 403, code)
   }
 }
 
-class ExpirationError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'ExpirationError'
-    this.status = 410
+class NotFoundError extends AbstractError {
+  constructor (message = 'Not found', code = 'NOT_FOUND') {
+    super(message, 404, code)
   }
 }
 
-class EmailSendError extends Error {
-  constructor (message) {
-    super(message || 'Error sending email')
-    this.name = 'EmailSendError'
-    this.status = 500
+class ExpirationError extends AbstractError {
+  constructor (message = 'Expired', code = 'EXPIRED') {
+    super(message, 410, code)
+  }
+}
+
+class EmailSendError extends AbstractError {
+  constructor (message = 'Error sending email', code = 'EMAIL_SEND') {
+    super(message, 500, code)
   }
 }
 


### PR DESCRIPTION
# Cambios realizados en las clases de error

1. **Clase AbstractError**:
   - Ahora acepta `message`, `code` y `status` en su constructor.
   - Establece automáticamente el nombre de la clase usando `this.constructor.name`.

2. **Subclases de error**:
   - Eliminado el constructor individual en cada subclase.
   - Ahora cada subclase llama al constructor de `AbstractError` con valores predeterminados.
   - Se agregaron mensajes por defecto para cada tipo de error.

3. **Eliminación de código repetitivo**:
   - Ya no es necesario establecer `this.name` en cada subclase.
   - No se requiere establecer `this.status` individualmente.

4. **Flexibilidad mejorada**:
   - Ahora es posible crear instancias de error sin pasar un mensaje (se usará el predeterminado).
   - Se mantiene la opción de pasar mensajes personalizados cuando sea necesario.

5. **Estandarización**:
   - Se agregaron códigos de error consistentes para cada tipo (ej. 'AUTH001', 'AUTH002', etc.).

6. **Exportación**:
   - La exportación de las clases se mantiene sin cambios.
